### PR TITLE
resolve issue when handling DateTimeOffset values

### DIFF
--- a/src/Parquet.Adla/Extractors/ParquetExtractor.cs
+++ b/src/Parquet.Adla/Extractors/ParquetExtractor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.Analytics.Interfaces;
 using Parquet.Data;
@@ -22,7 +23,15 @@ namespace Parquet.Adla.Extractors
             {
                int parquetIndex = _columnNameToIndex[outputColumn.Name];
                object value = parquetRow[parquetIndex];
-               output.Set(outputColumn.Name, value);
+
+               if (value is DateTimeOffset offset)
+               {
+                  output.Set(outputColumn.Name, offset.DateTime);
+               }
+               else
+               {
+                  output.Set(outputColumn.Name, value);
+               }
             }
 
             yield return output.AsReadOnly();


### PR DESCRIPTION
### Fixes

Resolves an issue with DateTimeOffset values

### Description

System.DateTimeOffset is not a valid type for extracting data, however a parquet file can arrive with a DateTimeOffset value. This fix checks for the type and simply returns it's DateTime value (note, it does not convert it to UTC)

### Todos
- [x] unit/integration tests
- [x] documentation
